### PR TITLE
Workaround the analyzer not working due to a not exist C# script under asmdef

### DIFF
--- a/Analyzers/Dummy.cs
+++ b/Analyzers/Dummy.cs
@@ -1,0 +1,6 @@
+﻿namespace NUnit.Analyzers
+{
+    public class Dummy
+    {
+    }
+}

--- a/Analyzers/Dummy.cs.meta
+++ b/Analyzers/Dummy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 34e945d8be6043d3a07e5367ccd508a0
+timeCreated: 1644089317


### PR DESCRIPTION
See [Roslyn analyzer does not work under asmdef without C# script file](https://fogbugz.unity3d.com/default.asp?1400869_55lf0evg4sqmj3se)